### PR TITLE
Update load_session argument in documentation

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -237,12 +237,12 @@ save_session(session=None,session_name=None)
 ## Restore Session from a Saved Session File
 
 ```python
-load_session(session_file_path=None,session=None)
+load_session(path=None,session=None)
     """
         Load a saved session.
 
         Args:
-            session_file_path (path, optional): File path to load session from. If None, shows a list of all saved session to choose from. Defaults to None.
+            path (path, optional): File path to load session from. If None, shows a list of all saved session to choose from. Defaults to None.
             session (request.Session, optional): requests.Session object to load a saved session into. Defaults to None.
 
         Returns:


### PR DESCRIPTION
The file path argument in [load_session() function](https://github.com/iSarabjitDhiman/TweeterPy/blob/2bcab9635b00bb4ab38b24b3c95d28266c8ad030/tweeterpy/utils/session.py#L54) is called `path` in the code but is currently in the documentation as: `session_file_path`. Updating the documentation to be `path`.