### PR TITLE
Fix: switch screen_name path from legacy to core

### DIFF
--- a/tweeterpy/tweeterpy.py
+++ b/tweeterpy/tweeterpy.py
@@ -229,7 +229,7 @@ class TweeterPy:
         if session is None:
             session = self.request_client.session
         if session_name is None:
-            session_name = self.me['data']['viewer']['user_results']['result']['legacy']['screen_name']
+            session_name = self.me['data']['viewer']['user_results']['result']['core']['screen_name']
         return save_session(filename=session_name, path=path, session=session)
 
     def load_session(self, path=None):


### PR DESCRIPTION
### Description
Response of `self.me` now exposes `screen_name` under `core` instead of `legacy`.  
- Changed lookup path https://github.com/iSarabjitDhiman/TweeterPy/blob/85a266e571d3e93aa26afce5d109f47929f3f5ec/tweeterpy/tweeterpy.py#L232